### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/poc-azure-github/1d082388-ab80-4841-ac52-c2eb2fa36a31/2fead5d6-6cae-4b15-be3e-a1a21baceed8/_apis/work/boardbadge/530b1c5b-7b58-4f2d-9ab8-24be4e6c662e)](https://dev.azure.com/poc-azure-github/1d082388-ab80-4841-ac52-c2eb2fa36a31/_boards/board/t/2fead5d6-6cae-4b15-be3e-a1a21baceed8/Microsoft.RequirementCategory)
 # react-hooks-typescript-example
 Project created and configured with react hooks and typescript


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/poc-azure-github/1d082388-ab80-4841-ac52-c2eb2fa36a31/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.